### PR TITLE
docker環境を修正

### DIFF
--- a/daily-report-tambourine-backend/docker-compose.yml
+++ b/daily-report-tambourine-backend/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   postgres:
     build: ./docker/postgres
-    image: postgres-latest
+    image: postgres-11.6
     container_name: ${APP_NAME}-postgres
     environment:
       POSTGRES_DB: ${DB_DATABASE}
@@ -26,7 +26,7 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       LANG: ja_JP.UTF-8
       TZ: Asia/Tokyo
-      DATABASE_HOST: localhost
+      DATABASE_HOST: postgres
     volumes:
       - ./docker/postgres/init:/docker-entrypoint-initdb.d
       - postgres_data:/var/lib/postgresql/data

--- a/daily-report-tambourine-backend/docker/php-apache/Dockerfile
+++ b/daily-report-tambourine-backend/docker/php-apache/Dockerfile
@@ -11,3 +11,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /composer
 ENV PATH $PATH:/composer/vendor/bin
+
+# rewrite headersを有効化
+RUN a2enmod rewrite headers

--- a/daily-report-tambourine-backend/docker/postgres/Dockerfile
+++ b/daily-report-tambourine-backend/docker/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:latest
+FROM postgres:11.6
 
 RUN localedef -i ja_JP -c -f UTF-8 -A /usr/share/locale/locale.alias ja_JP.UTF-8
 ENV LANG ja_JP.UTF-8


### PR DESCRIPTION
# 内容

- postgresql:のversion12でシステムテーブルのカラムが存在しなエラーが発生したため、バージョンを11.x系にダウングレードした [事象](https://stackoverflow.com/questions/58461178/how-to-fix-error-column-c-relhasoids-does-not-exist-in-postgres)
- apache2のRewrite Ruleが無効になっていたので、PHPのイメージビルド時に有効にするコマンドを追加

@KodaiD ご確認をお願いします